### PR TITLE
ChromiumOS: Allow board specific override

### DIFF
--- a/ESIF/Packages/Installers/chrome/dptf.conf
+++ b/ESIF/Packages/Installers/chrome/dptf.conf
@@ -13,6 +13,13 @@ respawn
 script
 	DPTF_OPTS=""
 	DPTF_FILE="$(cros_config /thermal dptf-dv)" || true
+	if [ -z "${DPTF_FILE}" ]; then
+	  if [ -f "/etc/dptf/dptf_override.sh" ]; then
+	    . /etc/dptf/dptf_override.sh
+		DPTF_FILE="$(dptf_get_override)"
+	  fi
+	fi
+
 	if [ -n "${DPTF_FILE}" ]; then
 		dptf="/etc/dptf/${DPTF_FILE}"
 		if [ ! -f "${dptf}" ]; then


### PR DESCRIPTION
Patch dptf.conf to look for /etc/dptf/dptf_override.sh
when starting dptf service and use the board specific
override dptf config if exists.

Signed-off-by: Puthikorn Voravootivat <puthik@chromium.org>